### PR TITLE
회원 삭제 soft delete로 변경

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/application/auth/UserLoginService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/auth/UserLoginService.java
@@ -23,7 +23,7 @@ public class UserLoginService implements AuthenticationService {
 
     @Override
     public String login(LoginRequest loginRequest) {
-        User user = repository.findByEmail(loginRequest.getEmail())
+        User user = repository.findByEmailAndDeletedIsFalse(loginRequest.getEmail())
                 .orElseThrow(() -> new UserNotFoundException("회원을 찾을 수 없으므로 로그인에 실패했습니다."));
 
         if (!user.authenticate(loginRequest.getPassword(), passwordEncoder)) {

--- a/app/src/main/java/com/codesoom/assignment/application/users/UserCommandService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/users/UserCommandService.java
@@ -48,7 +48,7 @@ public class UserCommandService implements UserSaveService, UserUpdateService, U
                 .orElseThrow(() ->
                         new UserNotFoundException(String.format("%s에 해당하는 회원을 찾을 수 없어 삭제에 실패하였습니다.", id)));
 
-        repository.delete(user);
+        user.destroy();
     }
 
 }

--- a/app/src/main/java/com/codesoom/assignment/application/users/UserCommandService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/users/UserCommandService.java
@@ -32,7 +32,7 @@ public class UserCommandService implements UserSaveService, UserUpdateService, U
 
     @Override
     public User updateUser(Long id, UserSaveRequest userSaveRequest) {
-        User user = repository.findById(id)
+        User user = repository.findByIdAndDeletedIsFalse(id)
                 .orElseThrow(() ->
                         new UserNotFoundException(String.format("%s에 해당하는 회원을 찾을 수 없어 수정에 실패하였습니다.", id)));
 
@@ -43,12 +43,13 @@ public class UserCommandService implements UserSaveService, UserUpdateService, U
     }
 
     @Override
-    public void deleteUser(Long id) {
-        User user = repository.findById(id)
+    public User deleteUser(Long id) {
+        User user = repository.findByIdAndDeletedIsFalse(id)
                 .orElseThrow(() ->
                         new UserNotFoundException(String.format("%s에 해당하는 회원을 찾을 수 없어 삭제에 실패하였습니다.", id)));
 
         user.destroy();
+        return user;
     }
 
 }

--- a/app/src/main/java/com/codesoom/assignment/application/users/UserDeleteService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/users/UserDeleteService.java
@@ -1,5 +1,6 @@
 package com.codesoom.assignment.application.users;
 
+import com.codesoom.assignment.domain.users.User;
 import com.codesoom.assignment.exceptions.UserNotFoundException;
 
 /**
@@ -13,6 +14,6 @@ public interface UserDeleteService {
      * @param id 회원 식별자
      * @throws UserNotFoundException 식별자로 회원을 찾지 못한 경우
      */
-    void deleteUser(Long id);
+    User deleteUser(Long id);
 
 }

--- a/app/src/main/java/com/codesoom/assignment/application/users/UserDeleteService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/users/UserDeleteService.java
@@ -8,7 +8,7 @@ import com.codesoom.assignment.exceptions.UserNotFoundException;
 public interface UserDeleteService {
 
     /**
-     * 식별자에 해당하는 회원 정보를 삭제합니다.
+     * 식별자에 해당하는 회원의 삭제 상태를 true로 변경합니다.
      *
      * @param id 회원 식별자
      * @throws UserNotFoundException 식별자로 회원을 찾지 못한 경우

--- a/app/src/main/java/com/codesoom/assignment/domain/users/User.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/users/User.java
@@ -1,9 +1,6 @@
 package com.codesoom.assignment.domain.users;
 
-import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Column;
@@ -12,7 +9,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-@Getter
+
 @Entity
 public class User {
 
@@ -71,10 +68,30 @@ public class User {
         return passwordEncoder.matches(rawPassword, this.password);
     }
 
-    /** 회원 삭제 시 삭제 여부를 변경한다. */
+    /** 이 회원을 삭제 상태로 변경하고, 변경된 회원을 리턴합니다. */
     public User destroy() {
         this.deleted = Boolean.TRUE;
         return this;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Boolean isDeleted() {
+        return deleted;
     }
 
 }

--- a/app/src/main/java/com/codesoom/assignment/domain/users/User.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/users/User.java
@@ -1,6 +1,8 @@
 package com.codesoom.assignment.domain.users;
 
 import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.Column;
@@ -24,6 +26,9 @@ public class User {
 
     @Column
     private String password;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean deleted = Boolean.FALSE;
 
     protected User() {
     }
@@ -62,6 +67,12 @@ public class User {
 
     public boolean authenticate(String rawPassword, PasswordEncoder passwordEncoder) {
         return passwordEncoder.matches(rawPassword, this.password);
+    }
+
+    /** 회원 삭제 시 삭제 여부를 변경한다. */
+    public User destroy() {
+        this.deleted = Boolean.TRUE;
+        return this;
     }
 
 }

--- a/app/src/main/java/com/codesoom/assignment/domain/users/User.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/users/User.java
@@ -1,6 +1,7 @@
 package com.codesoom.assignment.domain.users;
 
 import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,7 +28,8 @@ public class User {
     @Column
     private String password;
 
-    @Column(columnDefinition = "boolean default false")
+    @ColumnDefault("false")
+    @Column(insertable = false)
     private Boolean deleted = Boolean.FALSE;
 
     protected User() {

--- a/app/src/main/java/com/codesoom/assignment/domain/users/UserRepository.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/users/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends CrudRepository<User, Long> {
         return save(userSaveRequest.user());
     }
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndDeletedIsFalse(String email);
 
     Optional<User> findByIdAndDeletedIsFalse(Long id);
 

--- a/app/src/main/java/com/codesoom/assignment/domain/users/UserRepository.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/users/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends CrudRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByIdAndDeletedIsFalse(Long id);
+
 }

--- a/app/src/test/java/com/codesoom/assignment/application/auth/AuthenticationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/auth/AuthenticationServiceTest.java
@@ -4,7 +4,6 @@ import com.codesoom.assignment.application.ServiceTest;
 import com.codesoom.assignment.exceptions.UserNotFoundException;
 import com.codesoom.assignment.domain.users.User;
 import com.codesoom.assignment.domain.users.UserRepository;
-import com.codesoom.assignment.domain.users.UserSaveDto;
 import com.codesoom.assignment.exceptions.InvalidPasswordException;
 import com.codesoom.assignment.utils.JwtUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -151,7 +150,7 @@ class AuthenticationServiceTest extends ServiceTest {
 
             @BeforeEach
             void setup() {
-                User user = repository.findByEmail(NOT_EXIST_USER_EMAIL).orElse(null);
+                User user = repository.findByEmailAndDeletedIsFalse(NOT_EXIST_USER_EMAIL).orElse(null);
                 if (user != null) {
                     repository.delete(user);
                 }

--- a/app/src/test/java/com/codesoom/assignment/application/users/UserDeleteServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/users/UserDeleteServiceTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -62,7 +60,7 @@ public class UserDeleteServiceTest extends ServiceTest {
             void it_will_delete_user() {
                 User user = service.deleteUser(EXIST_ID);
 
-                assertThat(user.getDeleted()).isTrue();
+                assertThat(user.isDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/application/users/UserDeleteServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/users/UserDeleteServiceTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -55,12 +57,12 @@ public class UserDeleteServiceTest extends ServiceTest {
                         .getId();
             }
 
-            @DisplayName("성공적으로 회원을 삭제한다.")
+            @DisplayName("회원의 삭제 상태를 true로 변경한다.")
             @Test
             void it_will_delete_user() {
-                service.deleteUser(EXIST_ID);
+                User user = service.deleteUser(EXIST_ID);
 
-                assertThat(repository.findById(EXIST_ID)).isEmpty();
+                assertThat(user.getDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/controller/session/SessionControllerMockMvcTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/session/SessionControllerMockMvcTest.java
@@ -134,7 +134,7 @@ public class SessionControllerMockMvcTest extends ControllerTest {
 
             @BeforeEach
             void setup() {
-                User user = repository.findByEmail(NOT_EXIST_USER_EMAIL).orElse(null);
+                User user = repository.findByEmailAndDeletedIsFalse(NOT_EXIST_USER_EMAIL).orElse(null);
                 if(user != null) {
                     repository.delete(user);
                 }

--- a/app/src/test/java/com/codesoom/assignment/controller/session/SessionControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/session/SessionControllerTest.java
@@ -122,7 +122,7 @@ class SessionControllerTest {
 
             @BeforeEach
             void setup() {
-                User user = repository.findByEmail(NOT_EXIST_USER_EMAIL).orElse(null);
+                User user = repository.findByEmailAndDeletedIsFalse(NOT_EXIST_USER_EMAIL).orElse(null);
                 if(user != null) {
                     repository.delete(user);
                 }

--- a/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerMockMvcTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerMockMvcTest.java
@@ -80,7 +80,7 @@ public class UserDeleteControllerMockMvcTest extends ControllerTest {
                                 .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + TOKEN))
                         .andExpect(status().isNoContent());
 
-                assertThat(repository.findById(USER_ID)).isEmpty();
+                assertThat(repository.findById(USER_ID).get().getDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerMockMvcTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerMockMvcTest.java
@@ -80,7 +80,7 @@ public class UserDeleteControllerMockMvcTest extends ControllerTest {
                                 .header(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + TOKEN))
                         .andExpect(status().isNoContent());
 
-                assertThat(repository.findById(USER_ID).get().getDeleted()).isTrue();
+                assertThat(repository.findById(USER_ID).get().isDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerTest.java
@@ -74,7 +74,7 @@ public class UserDeleteControllerTest {
             void it_will_delete_user() {
                 controller.deleteUser(EXIST_ID);
 
-                assertThat(repository.findById(EXIST_ID).get().getDeleted()).isTrue();
+                assertThat(repository.findById(EXIST_ID).get().isDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controller/users/UserDeleteControllerTest.java
@@ -74,7 +74,7 @@ public class UserDeleteControllerTest {
             void it_will_delete_user() {
                 controller.deleteUser(EXIST_ID);
 
-                assertThat(repository.findById(EXIST_ID)).isEmpty();
+                assertThat(repository.findById(EXIST_ID).get().getDeleted()).isTrue();
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/domain/users/UserTest.java
+++ b/app/src/test/java/com/codesoom/assignment/domain/users/UserTest.java
@@ -127,18 +127,41 @@ public class UserTest {
         }
     }
 
-    @DisplayName("destroy 메서드는")
+    @DisplayName("isDeleted 메서드는")
     @Nested
-    class Describe_destroy {
+    class Describe_is_deleted {
 
-        @DisplayName("deleted 필드를 true로 변경한다.")
-        @Test
-        void it_is_deleted_ture() {
-            User user = User.of("홍길동", "test@codesooem.com");
-            user.destroy();
+        @DisplayName("삭제 상태가 아니라면")
+        @Nested
+        class Context_when_not_invoked_destroy {
 
-            assertThat(user.getDeleted()).isTrue();
+            final User user = User.of("홍길동", "test@codesooem.com");
+
+            @DisplayName("false를 반환한다.")
+            @Test
+            void it_returns_false() {
+                assertThat(user.isDeleted()).isFalse();
+            }
         }
+
+        @DisplayName("삭제 상태라면")
+        @Nested
+        class Context_when_invoked_destroy {
+
+            final User user = User.of("홍길동", "test@codesooem.com");
+
+            @BeforeEach
+            void setup() {
+                user.destroy();
+            }
+
+            @DisplayName("true를 반환한다.")
+            @Test
+            void it_returns_false() {
+                assertThat(user.isDeleted()).isTrue();
+            }
+        }
+
     }
 
 }

--- a/app/src/test/java/com/codesoom/assignment/domain/users/UserTest.java
+++ b/app/src/test/java/com/codesoom/assignment/domain/users/UserTest.java
@@ -127,5 +127,18 @@ public class UserTest {
         }
     }
 
+    @DisplayName("destroy 메서드는")
+    @Nested
+    class Describe_destroy {
+
+        @DisplayName("deleted 필드를 true로 변경한다.")
+        @Test
+        void it_is_deleted_ture() {
+            User user = User.of("홍길동", "test@codesooem.com");
+            user.destroy();
+
+            assertThat(user.getDeleted()).isTrue();
+        }
+    }
 
 }


### PR DESCRIPTION
회원 삭제 시 데이터를 실제로 삭제하지 않고, 삭제 상태를 변경하는 soft delete 방식으로 수정했습니다.

회원 탈퇴 후 바로 데이터를 삭제해 버리면,
- 배송 중인 고양이 장난감 상품의 출고 처리 문제
- 탈퇴 후 일정기간 동안 재가입 방지 불가

의 문제점을 발견했기 때문입니다.

`User` 엔티티 클래스에 `deleted` 필드를 추가해 삭제 상태를 나타내고, 삭제 상태로 변경되게 하는 `destroy` 메서드도 추가했습니다.
자세한 사용 방법은 테스트 코드를 참고해 주시기 바랍니다.