### PR TITLE
Authentication Interceptor 와 WebConfig 구현

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/application/authentication/AuthenticationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/authentication/AuthenticationService.java
@@ -3,12 +3,12 @@ package com.codesoom.assignment.application.authentication;
 import com.codesoom.assignment.UserNotFoundException;
 import com.codesoom.assignment.domain.User;
 import com.codesoom.assignment.domain.UserRepository;
+import com.codesoom.assignment.exceptions.InvalidTokenException;
 import com.codesoom.assignment.exceptions.LoginFailException;
 import com.codesoom.assignment.utils.JwtUtil;
 import io.jsonwebtoken.Claims;
 import org.springframework.stereotype.Service;
 
-import javax.security.auth.message.AuthException;
 
 @Service
 public class AuthenticationService {
@@ -41,7 +41,7 @@ public class AuthenticationService {
      * @param accessToken Claim에 id가 담겨있는 토큰
      * @return 토큰에 포함된 id
      */
-    public Long parseToken(String accessToken) throws AuthException {
+    public Long parseToken(String accessToken) throws InvalidTokenException {
         Claims claims = jwtUtil.decode(accessToken);
         return claims.get("id", Long.class);
     }

--- a/app/src/main/java/com/codesoom/assignment/config/web/WebConfig.java
+++ b/app/src/main/java/com/codesoom/assignment/config/web/WebConfig.java
@@ -1,0 +1,20 @@
+package com.codesoom.assignment.config.web;
+
+import com.codesoom.assignment.interceptors.AuthenticationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthenticationInterceptor authenticationInterceptor;
+
+    WebConfig(AuthenticationInterceptor authenticationInterceptor) {
+        this.authenticationInterceptor = authenticationInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/interceptors/AuthenticationInterceptor.java
+++ b/app/src/main/java/com/codesoom/assignment/interceptors/AuthenticationInterceptor.java
@@ -29,20 +29,20 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         String path = request.getRequestURI();
         String method = request.getMethod();
         if (path.startsWith("/products") && (
-                method.equals("GET") || method.equals("OPTIONS"))
+                "GET".equals(method) || "OPTIONS".equals(method))
         ) {
             return true;
         }
 
         if ((path.startsWith("/session") || path.startsWith("/users"))
-                && method.equals("POST")) {
+                && "POST".equals(method)) {
             return true;
         }
         return false;
     }
 
     /**
-     * 유효한 토큰으로 요청을 했는지 확인
+     * 유효한 토큰으로 요청했다면 true, 그렇지 않다면 false를 리턴합니다
      * @param request 요청
      * @param response 응답
      * @return {@code request} 에 있는 토큰이 유효한지 확인

--- a/app/src/main/java/com/codesoom/assignment/interceptors/AuthenticationInterceptor.java
+++ b/app/src/main/java/com/codesoom/assignment/interceptors/AuthenticationInterceptor.java
@@ -1,0 +1,68 @@
+package com.codesoom.assignment.interceptors;
+
+import com.codesoom.assignment.application.authentication.AuthenticationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+    private final AuthenticationService authenticationService;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+            ) throws Exception {
+        return filterWithPathAndMethod(request) ||
+                doAuthentication(request, response);
+    }
+
+    private boolean filterWithPathAndMethod(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+        if (path.startsWith("/products") && (
+                method.equals("GET") || method.equals("OPTIONS"))
+        ) {
+            return true;
+        }
+
+        if ((path.startsWith("/session") || path.startsWith("/users"))
+                && method.equals("POST")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 유효한 토큰으로 요청을 했는지 확인
+     * @param request 요청
+     * @param response 응답
+     * @return {@code request} 에 있는 토큰이 유효한지 확인
+     */
+    private boolean doAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws IOException {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || authorization.isBlank()) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value());
+            return false;
+        }
+
+        String accessToken = authorization.substring("Bearer ".length());
+        Long id = authenticationService.parseToken(accessToken);
+
+        request.setAttribute("id", id);
+
+        return true;
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
@@ -29,7 +29,7 @@ public class JwtUtil {
                 .compact();
     }
 
-    public Claims decode(String token) throws AuthException {
+    public Claims decode(String token) throws InvalidTokenException {
         if (token == null || token.isBlank()) {
             throw new InvalidTokenException(token);
         }


### PR DESCRIPTION
Interceptor에서 Request Path 와 Request Method 로 filtering 구현
Interceptor에서 header의 Authorization 을 가져와 토큰을 검사하는 doAuthentication 메소드 구현
WebConfig 클래스에서 AuthenticationInterceptor를 등록

#### 알아가는 점
현재 사용중인 프레임워크에서 Filter 와 Interceptor를 구현하여 중복된 코드 작성을 없애기 위해 사용하고 있었는데,
이를 Spring 에서 마주쳐서 반가웠습니다.
제가 원하는 방향은 `annotation` 으로 `Authorization`을 만들어 해당 어노테이션이 있는 Method만 AuthenticationInterceptor를 통하게끔 변경하고 싶었는데, 시도 중 우선은 강의를 따라서 해보는 것 또한 큰 의미가 있을것 같아 강의대로 먼저 PR를 날렸습니다.